### PR TITLE
Updated pom.xml file to fix build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
   		<groupId>org.apache.maven.plugins</groupId>
   		<artifactId>maven-shade-plugin</artifactId>
-  		<version>2.0</version>
+  		<version>2.1</version>
   		<configuration>
   		</configuration>
   		<executions>


### PR DESCRIPTION
I was getting the following error while trying to build. Upgrading the shade plugin fixes the error.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade (default) on project elasticrawl-examples: Execution default of goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade failed: A required class was missing while executing org.apache.maven.plugins:maven-shade-plugin:2.0:shade: org/sonatype/aether/graph/Dependency
